### PR TITLE
Fixed line of code that would cause game to crash on boot after compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,10 @@ ipch
 *.vcxproj
 *.vpc_crc
 *.sln
-*.res
+*.pdb
+*.db
+*.opendb
+*.lib
 .vs/
 Release*/
 Debug*/

--- a/src/game/client/cstrike15/VGUI/cstrikeclientscoreboard.cpp
+++ b/src/game/client/cstrike15/VGUI/cstrikeclientscoreboard.cpp
@@ -372,7 +372,11 @@ void CCSClientScoreBoardDialog::SetupTeamDisplay( TeamDisplayInfo& teamDisplay, 
 	teamDisplay.scoreAreaInnerHeight = playerTall - 2 * marginY;
 	teamDisplay.scoreAreaLinePreferredLeading = RoundFloatToInt(teamDisplay.scoreAreaLineHeight * kTeamScoreLineLeadingRatio);
 	teamDisplay.scoreAreaStartY = playerY + marginY;
-	teamDisplay.maxPlayersVisible = MIN(cMaxScoreLines, teamDisplay.scoreAreaInnerHeight / teamDisplay.scoreAreaLineHeight);
+	//teamDisplay.maxPlayersVisible = MIN(cMaxScoreLines, teamDisplay.scoreAreaInnerHeight / teamDisplay.scoreAreaLineHeight);
+	//^ previous code divided by zero and would cause a startup crash
+	
+	float lineHeight = MAX(teamDisplay.scoreAreaLineHeight, 1.0f);
+	teamDisplay.maxPlayersVisible = MIN(cMaxScoreLines, teamDisplay.scoreAreaInnerHeight / lineHeight);
 
 	// Calculate the starting point for player data.
 	int startY = teamDisplay.scoreAreaStartY;


### PR DESCRIPTION
This PR also dragged in two commits from the repo above mine, but this PR is primarily to fix some code that causes the program to crash immediately when booting it up.

It changes

`teamDisplay.maxPlayersVisible = MIN(cMaxScoreLines, teamDisplay.scoreAreaInnerHeight / teamDisplay.scoreAreaLineHeight);`

to

```
float lineHeight = MAX(teamDisplay.scoreAreaLineHeight, 1.0f);
	teamDisplay.maxPlayersVisible = MIN(cMaxScoreLines, teamDisplay.scoreAreaInnerHeight / lineHeight);
```

this is done in order to avoid dividing by zero or dividing by extremely small values, causing crashing/other issues

there may be a better way to handle this and if so, please feel free to leave messages here, I'd love to hear them 